### PR TITLE
Refactor/improve console logging and errors

### DIFF
--- a/commands/bootstrap.go
+++ b/commands/bootstrap.go
@@ -33,6 +33,7 @@ func BootstrapCommand(args map[string]interface{}) chan bool {
 	extractString(&options.Prefix, "prefix", args)
 	extractBool(&options.SetThemeId, "setThemeId", args)
 	extractThemeClient(&options.Client, args)
+	extractEventLog(&options.EventLog, args)
 
 	return Bootstrap(options)
 }

--- a/commands/common.go
+++ b/commands/common.go
@@ -13,6 +13,13 @@ type BasicOptions struct {
 	EventLog  chan phoenix.ThemeEvent
 }
 
+func (bo *BasicOptions) getEventLog() chan phoenix.ThemeEvent {
+	if bo.EventLog == nil {
+		bo.EventLog = make(chan phoenix.ThemeEvent)
+	}
+	return bo.EventLog
+}
+
 func extractString(s *string, key string, args map[string]interface{}) {
 	var ok bool
 	if args[key] == nil {
@@ -68,6 +75,22 @@ func extractThemeClient(t *phoenix.ThemeClient, args map[string]interface{}) {
 	if *t, ok = args["themeClient"].(phoenix.ThemeClient); !ok {
 		phoenix.NotifyError(errors.New("themeClient is not of a valid type"))
 	}
+}
+
+func extractEventLog(el *chan phoenix.ThemeEvent, args map[string]interface{}) {
+	var ok bool
+
+	if *el, ok = args["eventLog"].(chan phoenix.ThemeEvent); !ok {
+		phoenix.NotifyError(errors.New("eventLog is not of a valid type"))
+	}
+}
+
+func extractBasicOptions(args map[string]interface{}) BasicOptions {
+	options := BasicOptions{}
+	extractThemeClient(&options.Client, args)
+	extractEventLog(&options.EventLog, args)
+	options.Filenames = extractStringSlice("filenames", args)
+	return options
 }
 
 func toClientAndFilesAsync(args map[string]interface{}, fn func(phoenix.ThemeClient, []string) chan bool) chan bool {

--- a/commands/common.go
+++ b/commands/common.go
@@ -1,10 +1,17 @@
 package commands
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"github.com/csaunders/phoenix"
 )
+
+type BasicOptions struct {
+	Client    phoenix.ThemeClient
+	Filenames []string
+	EventLog  chan phoenix.ThemeEvent
+}
 
 func extractString(s *string, key string, args map[string]interface{}) {
 	var ok bool
@@ -16,6 +23,16 @@ func extractString(s *string, key string, args map[string]interface{}) {
 		errMsg := fmt.Sprintf("%s is not of valid type", key)
 		phoenix.NotifyError(errors.New(errMsg))
 	}
+}
+
+func extractStringSlice(key string, args map[string]interface{}) []string {
+	var ok bool
+	var strs []string
+	if strs, ok = args[key].([]string); !ok {
+		errMsg := fmt.Sprintf("%s is not of valid type", key)
+		phoenix.NotifyError(errors.New(errMsg))
+	}
+	return strs
 }
 
 func extractInt(s *int, key string, args map[string]interface{}) {
@@ -69,6 +86,60 @@ func drainErrors(errs chan error) {
 	for {
 		if err := <-errs; err != nil {
 			phoenix.NotifyError(err)
+		} else {
+			break
 		}
 	}
+}
+
+func mergeEvents(dest chan phoenix.ThemeEvent, chans []chan phoenix.ThemeEvent) {
+	go func() {
+		for _, ch := range chans {
+			var ok = true
+			for ok {
+				if ev, ok := <-ch; ok {
+					dest <- ev
+				}
+			}
+		}
+	}()
+}
+
+func logEvent(event phoenix.ThemeEvent, eventLog chan phoenix.ThemeEvent) {
+	go func() {
+		eventLog <- event
+	}()
+}
+
+type basicEvent struct {
+	Formatter func(b basicEvent) string
+	EventType string `json:"event_type"`
+	Target    string `json:"target"`
+	Title     string `json:"title"`
+	etype     string `json:"type"`
+}
+
+func message(content string) phoenix.ThemeEvent {
+	return basicEvent{
+		Formatter: func(b basicEvent) string { return content },
+		EventType: "message",
+		Title:     "Notice",
+		etype:     "basicEvent",
+	}
+}
+
+func (b basicEvent) String() string {
+	return b.Formatter(b)
+}
+
+func (b basicEvent) Successful() bool {
+	return true
+}
+
+func (b basicEvent) Error() error {
+	return nil
+}
+
+func (b basicEvent) AsJSON() ([]byte, error) {
+	return json.Marshal(b)
 }

--- a/commands/common.go
+++ b/commands/common.go
@@ -124,6 +124,7 @@ func mergeEvents(dest chan phoenix.ThemeEvent, chans []chan phoenix.ThemeEvent) 
 					dest <- ev
 				}
 			}
+			close(ch)
 		}
 	}()
 }

--- a/commands/configure.go
+++ b/commands/configure.go
@@ -24,7 +24,7 @@ func (co ConfigurationOptions) areInvalid() bool {
 	return co.Domain == "" || co.AccessToken == ""
 }
 
-func (co ConfigurationOptions) buildConfiguration() phoenix.Configuration {
+func (co ConfigurationOptions) defaultConfigurationOptions() phoenix.Configuration {
 	return phoenix.Configuration{
 		Domain:      co.Domain,
 		AccessToken: co.AccessToken,
@@ -48,10 +48,9 @@ func (co ConfigurationOptions) configurationErrors() error {
 	return nil
 }
 
-func ConfigureCommand(args map[string]interface{}) chan bool {
+func defaultOptions() ConfigurationOptions {
 	currentDir, _ := os.Getwd()
-
-	options := ConfigurationOptions{
+	return ConfigurationOptions{
 		Domain:      "",
 		AccessToken: "",
 		Directory:   currentDir,
@@ -59,6 +58,10 @@ func ConfigureCommand(args map[string]interface{}) chan bool {
 		BucketSize:  phoenix.DefaultBucketSize,
 		RefillRate:  phoenix.DefaultRefillRate,
 	}
+}
+
+func ConfigureCommand(args map[string]interface{}) chan bool {
+	options := defaultOptions()
 
 	extractString(&options.Environment, "environment", args)
 	extractString(&options.Directory, "directory", args)
@@ -66,6 +69,7 @@ func ConfigureCommand(args map[string]interface{}) chan bool {
 	extractString(&options.AccessToken, "access_token", args)
 	extractInt(&options.BucketSize, "bucket_size", args)
 	extractInt(&options.RefillRate, "refill_rate", args)
+	extractEventLog(&options.EventLog, args)
 
 	if options.areInvalid() {
 		phoenix.NotifyError(options.configurationErrors())
@@ -78,7 +82,7 @@ func ConfigureCommand(args map[string]interface{}) chan bool {
 }
 
 func Configure(options ConfigurationOptions) {
-	config := options.buildConfiguration()
+	config := options.defaultConfigurationOptions()
 	AddConfiguration(options.Directory, options.Environment, config)
 }
 

--- a/commands/configure.go
+++ b/commands/configure.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 	"github.com/csaunders/phoenix"
 	"io/ioutil"
@@ -9,32 +10,76 @@ import (
 	"strings"
 )
 
-func ConfigureCommand(args map[string]interface{}) (done chan bool) {
-	currentDir, _ := os.Getwd()
-	environment := phoenix.DefaultEnvironment
-	var dir, domain, accessToken string = currentDir, "", ""
-	var bucketSize, refillRate int = phoenix.DefaultBucketSize, phoenix.DefaultRefillRate
-
-	extractString(&environment, "environment", args)
-	extractString(&dir, "directory", args)
-	extractString(&domain, "domain", args)
-	extractString(&accessToken, "access_token", args)
-	extractInt(&bucketSize, "bucket_size", args)
-	extractInt(&refillRate, "refill_rate", args)
-
-	if domain == "" || accessToken == "" {
-		reportArgumentsError(dir, domain, accessToken)
-	}
-
-	Configure(dir, environment, domain, accessToken, bucketSize, refillRate)
-	done = make(chan bool)
-	close(done)
-	return
+type ConfigurationOptions struct {
+	BasicOptions
+	Directory   string
+	Environment string
+	Domain      string
+	AccessToken string
+	BucketSize  int
+	RefillRate  int
 }
 
-func Configure(dir, environment, domain, accessToken string, bucketSize, refillRate int) {
-	config := phoenix.Configuration{Domain: domain, AccessToken: accessToken, BucketSize: bucketSize, RefillRate: refillRate}
-	AddConfiguration(dir, environment, config)
+func (co ConfigurationOptions) areInvalid() bool {
+	return co.Domain == "" || co.AccessToken == ""
+}
+
+func (co ConfigurationOptions) buildConfiguration() phoenix.Configuration {
+	return phoenix.Configuration{
+		Domain:      co.Domain,
+		AccessToken: co.AccessToken,
+		BucketSize:  co.BucketSize,
+		RefillRate:  co.RefillRate,
+	}
+}
+
+func (co ConfigurationOptions) configurationErrors() error {
+	var errs = []string{}
+	if len(co.Domain) <= 0 {
+		errs = append(errs, "\t-domain cannot be blank")
+	}
+	if len(co.AccessToken) <= 0 {
+		errs = append(errs, "\t-access_token cannot be blank")
+	}
+	if len(errs) > 0 {
+		fullPath := filepath.Join(co.Directory, "config.yml")
+		return errors.New(fmt.Sprintf("Cannot create %s!\nErrors:\n%s", fullPath, strings.Join(errs, "\n")))
+	}
+	return nil
+}
+
+func ConfigureCommand(args map[string]interface{}) chan bool {
+	currentDir, _ := os.Getwd()
+
+	options := ConfigurationOptions{
+		Domain:      "",
+		AccessToken: "",
+		Directory:   currentDir,
+		Environment: phoenix.DefaultEnvironment,
+		BucketSize:  phoenix.DefaultBucketSize,
+		RefillRate:  phoenix.DefaultRefillRate,
+	}
+
+	extractString(&options.Environment, "environment", args)
+	extractString(&options.Directory, "directory", args)
+	extractString(&options.Domain, "domain", args)
+	extractString(&options.AccessToken, "access_token", args)
+	extractInt(&options.BucketSize, "bucket_size", args)
+	extractInt(&options.RefillRate, "refill_rate", args)
+
+	if options.areInvalid() {
+		phoenix.NotifyError(options.configurationErrors())
+	}
+
+	Configure(options)
+	done := make(chan bool)
+	close(done)
+	return done
+}
+
+func Configure(options ConfigurationOptions) {
+	config := options.buildConfiguration()
+	AddConfiguration(options.Directory, options.Environment, config)
 }
 
 func AddConfiguration(dir, environment string, config phoenix.Configuration) {
@@ -48,14 +93,16 @@ func AddConfiguration(dir, environment string, config phoenix.Configuration) {
 	}
 }
 
-func MigrateConfigurationCommand(args map[string]interface{}) (done chan bool) {
+func MigrateConfigurationCommand(args map[string]interface{}) (done chan bool, log chan phoenix.ThemeEvent) {
 	dir, _ := os.Getwd()
 	extractString(&dir, "directory", args)
 
 	MigrateConfiguration(dir)
 
 	done = make(chan bool)
+	log = make(chan phoenix.ThemeEvent)
 	close(done)
+	close(log)
 	return
 }
 
@@ -80,20 +127,4 @@ func loadOrInitializeEnvironment(location string) phoenix.Environments {
 		env[phoenix.DefaultEnvironment] = conf
 	}
 	return env
-}
-
-func reportArgumentsError(directory, domain, accessToken string) {
-	var errors = []string{}
-	if len(domain) <= 0 {
-		errors = append(errors, "\t-domain cannot be blank")
-	}
-	if len(accessToken) <= 0 {
-		errors = append(errors, "\t-access_token cannot be blank")
-	}
-	if len(errors) > 0 {
-		fullPath := filepath.Join(directory, "config.yml")
-		errorMessage := phoenix.RedText(fmt.Sprintf("Cannot create %s!\nErrors:\n%s", fullPath, strings.Join(errors, "\n")))
-		fmt.Println(errorMessage)
-		os.Exit(1)
-	}
 }

--- a/commands/download.go
+++ b/commands/download.go
@@ -114,7 +114,7 @@ func writeToDisk(asset phoenix.Asset, eventLog chan phoenix.ThemeEvent) {
 			Target:    filename,
 			etype:     "fsevent",
 			Formatter: func(b basicEvent) string {
-				return fmt.Sprintf("Successfully wrote %s to disk", b.Target)
+				return phoenix.GreenText(fmt.Sprintf("Successfully wrote %s to disk", b.Target))
 			},
 		}
 		logEvent(event, eventLog)

--- a/commands/download.go
+++ b/commands/download.go
@@ -2,9 +2,9 @@ package commands
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"github.com/csaunders/phoenix"
-	"log"
 	"os"
 	"path/filepath"
 )
@@ -15,23 +15,24 @@ func DownloadCommand(args map[string]interface{}) chan bool {
 
 func Download(client phoenix.ThemeClient, filenames []string) (done chan bool) {
 	done = make(chan bool)
+	eventLog := make(chan phoenix.ThemeEvent)
 
 	if len(filenames) <= 0 {
 		assets, errs := client.AssetList()
 		go drainErrors(errs)
-		go downloadAllFiles(assets, done)
+		go downloadAllFiles(assets, done, eventLog)
 	} else {
-		go downloadFiles(client.Asset, filenames, done)
+		go downloadFiles(client.Asset, filenames, done, eventLog)
 	}
 
 	return done
 }
 
-func downloadAllFiles(assets chan phoenix.Asset, done chan bool) {
+func downloadAllFiles(assets chan phoenix.Asset, done chan bool, eventLog chan phoenix.ThemeEvent) {
 	for {
 		asset, more := <-assets
 		if more {
-			writeToDisk(asset)
+			writeToDisk(asset, eventLog)
 		} else {
 			done <- true
 			return
@@ -39,41 +40,45 @@ func downloadAllFiles(assets chan phoenix.Asset, done chan bool) {
 	}
 }
 
-func downloadFiles(retrievalFunction phoenix.AssetRetrieval, filenames []string, done chan bool) {
+func downloadFiles(retrievalFunction phoenix.AssetRetrieval, filenames []string, done chan bool, eventLog chan phoenix.ThemeEvent) {
 	for _, filename := range filenames {
 		if asset, err := retrievalFunction(filename); err != nil {
 			phoenix.NotifyError(err)
 		} else {
-			writeToDisk(asset)
+			writeToDisk(asset, eventLog)
 		}
 	}
 	done <- true
 	return
 }
 
-func writeToDisk(asset phoenix.Asset) {
+func writeToDisk(asset phoenix.Asset, eventLog chan phoenix.ThemeEvent) {
 	dir, err := os.Getwd()
 	if err != nil {
-		log.Fatal("Could not get current working directory ", err)
+		phoenix.NotifyError(err)
+		return
 	}
 
 	perms, err := os.Stat(dir)
 	if err != nil {
-		log.Fatal("Could not get directory information ", err)
+		phoenix.NotifyError(err)
+		return
 	}
 
 	filename := fmt.Sprintf("%s/%s", dir, asset.Key)
 	err = os.MkdirAll(filepath.Dir(filename), perms.Mode())
 	if err != nil {
-		log.Fatal("Could not create parent directory ", err)
+		phoenix.NotifyError(err)
+		return
 	}
 
 	file, err := os.Create(filename)
+	if err != nil {
+		phoenix.NotifyError(err)
+		return
+	}
 	defer file.Sync()
 	defer file.Close()
-	if err != nil {
-		log.Fatal("Could not create ", filename, err)
-	}
 
 	var data []byte
 	switch {
@@ -82,7 +87,7 @@ func writeToDisk(asset phoenix.Asset) {
 	case len(asset.Attachment) > 0:
 		data, err = base64.StdEncoding.DecodeString(asset.Attachment)
 		if err != nil {
-			fmt.Println(fmt.Sprintf("Could not decode %s. error: %s", asset.Key, err))
+			phoenix.NotifyError(errors.New(fmt.Sprintf("Could not decode %s. error: %s", asset.Key, err)))
 			return
 		}
 	}
@@ -92,6 +97,17 @@ func writeToDisk(asset phoenix.Asset) {
 	}
 
 	if err != nil {
-		log.Fatal("Could not write file to disk ", err)
+		phoenix.NotifyError(err)
+	} else {
+		event := basicEvent{
+			Title:     "FS Event",
+			EventType: "Write",
+			Target:    filename,
+			etype:     "fsevent",
+			Formatter: func(b basicEvent) string {
+				return fmt.Sprintf("Successfully wrote %s to disk", b.Target)
+			},
+		}
+		logEvent(event, eventLog)
 	}
 }

--- a/commands/remove.go
+++ b/commands/remove.go
@@ -11,9 +11,8 @@ func RemoveCommand(args map[string]interface{}) chan bool {
 }
 
 func Remove(client phoenix.ThemeClient, filenames []string) (done chan bool) {
-	var messages chan phoenix.ThemeEvent
 	events := make(chan phoenix.AssetEvent)
-	done, messages = client.Process(events)
+	done, _ = client.Process(events)
 
 	go func() {
 		for _, filename := range filenames {
@@ -24,15 +23,6 @@ func Remove(client phoenix.ThemeClient, filenames []string) (done chan bool) {
 		close(events)
 	}()
 
-	go func() {
-		for {
-			message, more := <-messages
-			if !more {
-				return
-			}
-			fmt.Println(message)
-		}
-	}()
 	return done
 }
 

--- a/commands/replace.go
+++ b/commands/replace.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"fmt"
 	"github.com/csaunders/phoenix"
 )
 
@@ -11,13 +10,8 @@ func ReplaceCommand(args map[string]interface{}) chan bool {
 
 func Replace(client phoenix.ThemeClient, filenames []string) chan bool {
 	events := make(chan phoenix.AssetEvent)
-	done, messages := client.Process(events)
+	done, _ := client.Process(events)
 
-	go func() {
-		for {
-			fmt.Println(<-messages)
-		}
-	}()
 	assets, errs := assetList(client, filenames)
 	go drainErrors(errs)
 	go removeAndUpload(assets, events)

--- a/commands/upload.go
+++ b/commands/upload.go
@@ -1,9 +1,7 @@
 package commands
 
 import (
-	"fmt"
 	"github.com/csaunders/phoenix"
-	"log"
 	"os"
 )
 
@@ -11,22 +9,12 @@ func UploadCommand(args map[string]interface{}) chan bool {
 	return toClientAndFilesAsync(args, Upload)
 }
 
-func Upload(client phoenix.ThemeClient, filenames []string) (done chan bool) {
+func Upload(client phoenix.ThemeClient, filenames []string) chan bool {
 	files := make(chan phoenix.AssetEvent)
 	go readAndPrepareFiles(filenames, files)
 
-	done, messages := client.Process(files)
-	go func() {
-		for {
-			message, more := <-messages
-			if !more {
-				return
-			}
-			fmt.Println(message)
-		}
-	}()
-
-	return
+	done, _ := client.Process(files)
+	return done
 }
 
 func readAndPrepareFiles(filenames []string, results chan phoenix.AssetEvent) {
@@ -35,7 +23,7 @@ func readAndPrepareFiles(filenames []string, results chan phoenix.AssetEvent) {
 		if err == nil {
 			results <- phoenix.NewUploadEvent(asset)
 		} else if err.Error() != "File is a directory" {
-			log.Panic(err)
+			phoenix.NotifyError(err)
 		}
 	}
 	close(results)

--- a/commands/watch.go
+++ b/commands/watch.go
@@ -25,8 +25,10 @@ func WatchCommand(args map[string]interface{}) chan bool {
 	return Watch(client, dir)
 }
 
-func Watch(client phoenix.ThemeClient, dir string) (done chan bool) {
-	done = make(chan bool)
+func Watch(client phoenix.ThemeClient, dir string) chan bool {
+	done := make(chan bool)
+	eventLog := make(chan phoenix.ThemeEvent)
+
 	config := client.GetConfiguration()
 
 	bucket := phoenix.NewLeakyBucket(config.BucketSize, config.RefillRate, 1)
@@ -36,22 +38,30 @@ func Watch(client phoenix.ThemeClient, dir string) (done chan bool) {
 	foreman.JobQueue = watcher
 	foreman.IssueWork()
 
-	fmt.Println("Waiting for local changes")
+	logEvent(message(fmt.Sprintf("Spawning %d workers", config.Concurrency)), eventLog)
 	for i := 0; i < config.Concurrency; i++ {
-		go spawnWorker(i, foreman.WorkerQueue, client)
+		go spawnWorker(i, foreman.WorkerQueue, client, eventLog)
 	}
 
-	return
+	return done
 }
 
-func spawnWorker(workerId int, queue chan phoenix.AssetEvent, client phoenix.ThemeClient) {
-	fmt.Println(fmt.Sprintf("~~~~ Spawning Worker %d ~~~~", workerId))
+func spawnWorker(workerId int, queue chan phoenix.AssetEvent, client phoenix.ThemeClient, eventLog chan phoenix.ThemeEvent) {
+	logEvent(workerSpawnEvent(workerId), eventLog)
 	for {
 		asset := <-queue
 		if asset.Asset().IsValid() {
-			message := fmt.Sprintf("Received %s event on '%s'", asset.Type(), asset.Asset().Key)
-			fmt.Println(message)
-			fmt.Println(client.Perform(asset))
+			workerEvent := basicEvent{
+				Title:     "FS Event",
+				EventType: asset.Type().String(),
+				Target:    asset.Asset().Key,
+				etype:     "fsevent",
+				Formatter: func(b basicEvent) string {
+					return fmt.Sprintf("Received %s event on '%s'", b.EventType, b.Target)
+				},
+			}
+			logEvent(workerEvent, eventLog)
+			logEvent(client.Perform(asset), eventLog)
 		}
 	}
 }
@@ -59,4 +69,16 @@ func spawnWorker(workerId int, queue chan phoenix.AssetEvent, client phoenix.The
 func constructFileWatcher(dir string, config phoenix.Configuration) chan phoenix.AssetEvent {
 	filter := phoenix.NewEventFilterFromPatternsAndFiles(config.IgnoredFiles, config.Ignores)
 	return phoenix.NewFileWatcher(dir, true, filter)
+}
+
+func workerSpawnEvent(workerId int) phoenix.ThemeEvent {
+	return basicEvent{
+		Title:     "Worker",
+		Target:    fmt.Sprintf("%d", workerId),
+		etype:     "basicEvent",
+		EventType: "worker",
+		Formatter: func(b basicEvent) string {
+			return fmt.Sprintf("%s #%s ready to upload local changes", b.Title, b.Target)
+		},
+	}
 }

--- a/commands/watch.go
+++ b/commands/watch.go
@@ -55,7 +55,11 @@ func spawnWorker(workerId int, queue chan phoenix.AssetEvent, client phoenix.The
 				Target:    asset.Asset().Key,
 				etype:     "fsevent",
 				Formatter: func(b basicEvent) string {
-					return fmt.Sprintf("Received %s event on '%s'", b.EventType, b.Target)
+					return fmt.Sprintf(
+						"Received %s event on %s",
+						phoenix.GreenText(b.EventType),
+						phoenix.BlueText(b.Target),
+					)
 				},
 			}
 			logEvent(workerEvent, eventLog)

--- a/theme_event.go
+++ b/theme_event.go
@@ -27,12 +27,14 @@ type APIAssetEvent struct {
 	EventType string `json:"event_type"`
 	Code      int    `json:"status_code"`
 	err       error  `json:"error,omitempty"`
+	etype     string `json:"type"`
 }
 
 func NewAPIAssetEvent(r *http.Response, e AssetEvent, err error) APIAssetEvent {
 	event := APIAssetEvent{
 		AssetKey:  e.Asset().Key,
 		EventType: e.Type().String(),
+		etype:     "APIAssetEvent",
 	}
 	if err != nil {
 		event.Host = "Host Unknown"
@@ -82,13 +84,14 @@ type APIThemeEvent struct {
 	Code        int    `json:"status_code"`
 	Previewable bool   `json:"previewable,omitempty"`
 	err         error  `json:"error,omitempty"`
+	etype       string `json:"type"`
 }
 
 func NewAPIThemeEvent(r *http.Response, err error) APIThemeEvent {
 	if err != nil {
-		return APIThemeEvent{Host: "Unknown Host", Code: ThemeEventErrorCode, err: err}
+		return APIThemeEvent{Host: "Unknown Host", Code: ThemeEventErrorCode, err: err, etype: "APIThemeEvent"}
 	}
-	event := APIThemeEvent{Host: r.Request.URL.Host, Code: r.StatusCode}
+	event := APIThemeEvent{Host: r.Request.URL.Host, Code: r.StatusCode, etype: "APIThemeEvent"}
 
 	if event.Successful() {
 		populateThemeData(&event, r)
@@ -100,7 +103,7 @@ func NewAPIThemeEvent(r *http.Response, err error) APIThemeEvent {
 
 func (t APIThemeEvent) String() string {
 	if t.Successful() {
-		return fmt.Sprintf("[%d]Theme called '%s' with id of %d for shop %s", t.Code, t.ThemeName, t.ThemeId, t.Host)
+		return fmt.Sprintf("[%d]Modifications made to theme '%s' with id of %d on shop %s", t.Code, t.ThemeName, t.ThemeId, t.Host)
 	} else {
 		return fmt.Sprintf("[%d]Encoutered error with request to %s\n\t%s", t.Code, t.Host, t.err)
 	}

--- a/theme_event.go
+++ b/theme_event.go
@@ -53,11 +53,23 @@ func NewAPIAssetEvent(r *http.Response, e AssetEvent, err error) APIAssetEvent {
 
 func (a APIAssetEvent) String() string {
 	if a.Successful() {
-		return fmt.Sprintf("Successfully performed %s operation for file %s to %s", a.EventType, BlueText(a.AssetKey), BlueText(a.Host))
+		return fmt.Sprintf(
+			"Successfully performed %s operation for file %s to %s",
+			GreenText(a.EventType),
+			BlueText(a.AssetKey),
+			YellowText(a.Host),
+		)
 	} else if a.Code == 422 {
-		return fmt.Sprintf("Could not upload %s:\n\t%s", a.AssetKey, a.err)
+		return RedText(fmt.Sprintf("Could not upload %s:\n\t%s", a.AssetKey, a.err))
 	} else {
-		return fmt.Sprintf("[%d]Could not perform %s to %s at %s\n\t%s", a.Code, YellowText(a.EventType), BlueText(a.AssetKey), BlueText(a.Host), a.err)
+		return fmt.Sprintf(
+			"[%s]Could not perform %s to %s at %s\n\t%s",
+			RedText(fmt.Sprintf("%d", a.Code)),
+			YellowText(a.EventType),
+			BlueText(a.AssetKey),
+			YellowText(a.Host),
+			a.err,
+		)
 	}
 }
 
@@ -103,9 +115,20 @@ func NewAPIThemeEvent(r *http.Response, err error) APIThemeEvent {
 
 func (t APIThemeEvent) String() string {
 	if t.Successful() {
-		return fmt.Sprintf("[%d]Modifications made to theme '%s' with id of %d on shop %s", t.Code, t.ThemeName, t.ThemeId, t.Host)
+		return fmt.Sprintf(
+			"[%s]Modifications made to theme '%s' with id of %s on shop %s",
+			GreenText(fmt.Sprintf("%d", t.Code)),
+			BlueText(t.ThemeName),
+			BlueText(fmt.Sprintf("%d", t.ThemeId)),
+			YellowText(t.Host),
+		)
 	} else {
-		return fmt.Sprintf("[%d]Encoutered error with request to %s\n\t%s", t.Code, t.Host, t.err)
+		return fmt.Sprintf(
+			"[%s]Encoutered error with request to %s\n\t%s",
+			RedText(fmt.Sprintf("%d", t.Code)),
+			YellowText(t.Host),
+			t.err,
+		)
 	}
 }
 

--- a/utils.go
+++ b/utils.go
@@ -24,6 +24,10 @@ func BlueText(s string) string {
 	return fmt.Sprintf("\033[34m%s\033[0m", s)
 }
 
+func GreenText(s string) string {
+	return fmt.Sprintf("\033[32m%s\033[0m", s)
+}
+
 func TestFixture(name string) string {
 	path := fmt.Sprintf("fixtures/%s.json", name)
 	file, err := os.Open(path)


### PR DESCRIPTION
There shouldn't be anymore dying/panicking when something goes wrong anymore.
Uses a global error log, which kinda sucks.

`Options<Command>` objects to reduce the nastiness that was calling anything from the `commands` package.